### PR TITLE
Fix: Ensure scoped migration created in subdirectory

### DIFF
--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -51,7 +51,7 @@ async function executeCreateMigration (internals, config) {
   internals.argv.title = internals.argv._.shift();
   folder = internals.argv.title.split('/');
 
-  internals.argv.title = folder[folder.length - 2] || folder[0];
+  internals.argv.title = folder[folder.length - 1] || folder[0];
   path = migrationsDir;
 
   if (folder.length > 1) {
@@ -61,6 +61,7 @@ async function executeCreateMigration (internals, config) {
       path += folder[i] + '/';
     }
   }
+  internals.argv['migrations-dir'] = path
 
   let templateType = Migration.TemplateType.DEFAULT_JS;
   if (


### PR DESCRIPTION
db-migrate create someScope/aMigration --sql-file, the following is created:

./migrations/someScope/xxx-someScope.js
./migrations/sqls/xxx-someScope-up.sql
./migrations/sqls/xxx-someScope-down.sql
Instead, I expect:

./migrations/someScope/xxx-aMigration.js
./migrations/someScope/sqls/xxx-aMigration-up.sql
./migrations/someScope/sqls/xxx-aMigration-down.sql

Signed-off-by: Anson Tsao <atsao@goaddy.com>